### PR TITLE
Client post function fix

### DIFF
--- a/src/Phpforce/RestClient/Client.php
+++ b/src/Phpforce/RestClient/Client.php
@@ -58,7 +58,7 @@ class Client
     {
         $request = $this->getClient()->post($uri);
         $request->setHeader('Authorization', 'Bearer ' . $this->getSessionId());
-        $request->setBody(json_encode($arguments), 'application/json');
+        $request->getParams()->merge($arguments);
 
         $response = $request->send();
 

--- a/src/Phpforce/RestClient/Client.php
+++ b/src/Phpforce/RestClient/Client.php
@@ -58,7 +58,7 @@ class Client
     {
         $request = $this->getClient()->post($uri);
         $request->setHeader('Authorization', 'Bearer ' . $this->getSessionId());
-        $request->getParams()->merge($arguments);
+        $request->setBody(json_encode($arguments), 'application/json');
 
         $response = $request->send();
 


### PR DESCRIPTION
I discovered that the reason that this function was broken was because Salesforce expected a json array of arguments. This is provisional - maybe this is because it's a new version of their API?
